### PR TITLE
フォロー/フォロワー一覧に各ユーザのフォロー数・されてる数を表示する #17

### DIFF
--- a/app/views/users/_user.html.erb
+++ b/app/views/users/_user.html.erb
@@ -6,4 +6,10 @@
                                           turbo_confirm: "You sure?" } %>
   <% end %>
   <p><%= user.introduction %></p> 
+  <% if show_address %>
+  <%= user.following.count %>
+  フォロー
+  <%= user.followers.count %>
+  フォロワー
+  <% end %>
 </li>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -9,7 +9,7 @@
 <% if @users.any? %>
   <%= will_paginate %>
   <ul class='users'>
-    <%= render @users %>
+    <%= render @users , user: @user, show_address: false%>
   </ul>
   <%= will_paginate %>
 <% else %>

--- a/app/views/users/show_follow.html.erb
+++ b/app/views/users/show_follow.html.erb
@@ -22,7 +22,7 @@
     <h3><%= @title %></h3>
     <% if @users.any? %>
       <ul class="users follow">
-        <%= render @users %>
+        <%= render @users , user: @user, show_address: true%>
       </ul>
       <%= will_paginate %>
     <% end %>


### PR DESCRIPTION
#17 フォロー/フォロワー一覧に各ユーザのフォロー数・されてる数を表示する 
_user.html.erbを呼び出すときに同時にshow_addressの値を指定することで、値が真ならフォロー数とフォロワー数を表示、偽なら表示しないようにした
All Users画面では偽
![image](https://github.com/user-attachments/assets/d50f6330-5757-4750-93f9-6d70f500301b)
Following、Followers画面では真
![image](https://github.com/user-attachments/assets/fb7af418-4749-4e96-876d-e2928a00dce1)
![image](https://github.com/user-attachments/assets/0d27fe53-581a-418b-9c01-10d416f0e427)

